### PR TITLE
fix: clang static analyzer warning

### DIFF
--- a/bytehook/src/main/cpp/bh_elf_manager.c
+++ b/bytehook/src/main/cpp/bh_elf_manager.c
@@ -23,6 +23,7 @@
 
 #include <unistd.h>
 #include <stdint.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -185,6 +186,12 @@ void bh_elf_manager_iterate(bh_elf_manager_t *self, bh_elf_manager_iterate_cb_t 
             bh_elf_t *elf;
             RB_FOREACH(elf, bh_elf_tree, &self->elfs)
                 copy_elfs[i++] = elf;
+            if (i != copy_elfs_cnt)
+            {
+                assert(0);
+
+                goto err;
+            }
         }
     }
     pthread_rwlock_unlock(&self->elfs_lock);
@@ -199,6 +206,12 @@ void bh_elf_manager_iterate(bh_elf_manager_t *self, bh_elf_manager_iterate_cb_t 
         }
         free(copy_elfs);
     }
+
+    return;
+    
+err:
+    pthread_rwlock_unlock(&self->elfs_lock);
+    free(copy_elfs);
 }
 
 bh_elf_t *bh_elf_manager_find_elf(bh_elf_manager_t *self, const char *pathname)

--- a/bytehook/src/main/cpp/bh_elf_manager.c
+++ b/bytehook/src/main/cpp/bh_elf_manager.c
@@ -185,11 +185,19 @@ void bh_elf_manager_iterate(bh_elf_manager_t *self, bh_elf_manager_iterate_cb_t 
             size_t i = 0;
             bh_elf_t *elf;
             RB_FOREACH(elf, bh_elf_tree, &self->elfs)
+            {
                 copy_elfs[i++] = elf;
-            if (i != copy_elfs_cnt)
+                // memory overflow
+                if(i > copy_elfs_cnt)
+                {
+                    assert(0);
+                    goto err;
+                }
+            }
+            // ELF dirty count
+            if(i != copy_elfs_cnt)
             {
                 assert(0);
-
                 goto err;
             }
         }


### PR DESCRIPTION
```
> ~/Library/Android/sdk/ndk/21.4.7075529/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang --target=i686-none-linux-android16 --analyze --sysroot=~/Library/Android/sdk/ndk/21.4.7075529/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -I~/Documents/bhook/bytehook/src/main/cpp -I~/Documents/bhook/bytehook/src/main/cpp/include --analyzer-output html -o ./static_analyze_report ~/Documents/bhook/bytehook/src/main/cpp/bh_elf_manager.c
```
> include search path and sysroot should use canonical prefixes instead of ~

clang analyzer output as below
```
~/Documents/bhook/bytehook/src/main/cpp/bh_elf_manager.c:198:35: warning: 1st function call argument is an uninitialized value
            if(cb_next) cb_next = cb(copy_elfs[i], cb_arg);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```