### PR TITLE
Remove generating the BuildConfig on Android modules

### DIFF
--- a/bytehook/build.gradle
+++ b/bytehook/build.gradle
@@ -41,6 +41,7 @@ android {
     }
     buildFeatures {
         prefabPublishing true
+        buildConfig false
     }
     prefab {
         bytehook {


### PR DESCRIPTION
This PR Remove generating the BuildConfig on bytehook module.
