### PR TITLE
fix Android 4.x无法解析/proc/self/maps的BUG

### DIFF
--- a/bytehook/src/main/cpp/bh_dl_iterate.c
+++ b/bytehook/src/main/cpp/bh_dl_iterate.c
@@ -114,6 +114,7 @@ static int bh_dl_iterate_by_maps(int (*callback)(struct dl_phdr_info *, size_t, 
   bool try_next_line = false;
 
   while (fgets(line, sizeof(buf1), maps)) {
+    bh_util_trim_ending(line);
     // Parsing maps directly has too much uncertainty, so it needs to be strict.
     if (!bh_util_ends_with(line, BH_CONST_BASENAME_APP_PROCESS) && !bh_util_ends_with(line, ".so")) continue;
 


### PR DESCRIPTION
fgets函数获取的line字符串结尾包含换行符，需要先去除换行符